### PR TITLE
Adding docs for vue-router and release stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,26 @@ import Vue from 'vue';
 import VueBugsnag from 'vue-bugsnag';
 Vue.use(VueBugsnag);
 ```
-* Prevent development errors from reporting
+* Prevent Bugsnag from being initialized in development
 ```js
 if (process.env.NODE_ENV === 'production') {
-  // Initialize bugsnag here
+  //Initialize Bugsnag here
 }
+```
+
+* Limit error reporting to specific release stages
+
+```js
+Bugsnag.notifyReleaseStages = ['staging', 'production'];
+```
+
+## Use with Vue Router
+* Use an `afterEach` [navigation guard](https://router.vuejs.org/en/advanced/navigation-guards.html) to reset the Bugsnag error limit.
+
+```js
+router.afterEach((to, from) => {
+    Bugsnag.refresh();
+});
 ```
 
 ## Use in browser (without webpack)


### PR DESCRIPTION
Thank you for doing this! We just installed Bugsnag but couldn't find good Vue support. 

I wanted to add documentation for use with [Vue Router](https://router.vuejs.org/en/) to reset the error limit and I noticed you had docs for preventing errors in dev. Bugsnag also allows you to do this via `notifyReleaseStages` so I put that in as well. It's not directly related but may be useful to people using this.

Anyways thanks for putting this up.